### PR TITLE
Use system compiler linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,16 +13,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
     endif()
 endif()
 
-# Configure which abi to use (on linux)
-option(BUILD_WITH_GLIBCXX_CXX11_ABI "Use stdlibcxx11, for gcc >= 5, disable for gcc < 5" ON)
-
-if(BUILD_WITH_GLIBCXX_CXX11_ABI)
-    ADD_DEFINITIONS(-D_GLIBCXX_USE_CXX11_ABI=1)
-else()
-    # Use old ABI, for compatibility with GCC < 5
-    ADD_DEFINITIONS(-D_GLIBCXX_USE_CXX11_ABI=0)
-endif()
-
 find_package(OpenMP)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,6 @@ project(marching_cubes)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 
-
-
-
-
-
-
-
-
 include(CheckCXXCompilerFlag)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -21,6 +13,15 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
     endif()
 endif()
 
+# Configure which abi to use (on linux)
+option(BUILD_WITH_GLIBCXX_CXX11_ABI "Use stdlibcxx11, for gcc >= 5, disable for gcc < 5" ON)
+
+if(BUILD_WITH_GLIBCXX_CXX11_ABI)
+    ADD_DEFINITIONS(-D_GLIBCXX_USE_CXX11_ABI=1)
+else()
+    # Use old ABI, for compatibility with GCC < 5
+    ADD_DEFINITIONS(-D_GLIBCXX_USE_CXX11_ABI=0)
+endif()
 
 find_package(OpenMP)
 

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -30,8 +30,6 @@ cmake ..\
     -DPYTHON_EXECUTABLE=${PYTHON} \
     -DPYTHON_LIBRARY=${PREFIX}/lib/libpython${PY_ABI}.${DYLIB_EXT} \
     -DPYTHON_INCLUDE_DIR=${PREFIX}/include/python${PY_ABI} \
-    -DPYTHON_NUMPY_INCLUDE_DIR=${SP_DIR}/numpy/core/include \
-
 ##
 
 make -j${CPU_COUNT}

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -30,6 +30,8 @@ cmake ..\
     -DPYTHON_EXECUTABLE=${PYTHON} \
     -DPYTHON_LIBRARY=${PREFIX}/lib/libpython${PY_ABI}.${DYLIB_EXT} \
     -DPYTHON_INCLUDE_DIR=${PREFIX}/include/python${PY_ABI} \
+    -DPYTHON_NUMPY_INCLUDE_DIR=${SP_DIR}/numpy/core/include \
+
 ##
 
 make -j${CPU_COUNT}

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -34,7 +34,6 @@ cmake ..\
     -DPYTHON_EXECUTABLE=${PYTHON} \
     -DPYTHON_LIBRARY=${PREFIX}/lib/libpython${PY_ABI}.${DYLIB_EXT} \
     -DPYTHON_INCLUDE_DIR=${PREFIX}/include/python${PY_ABI} \
-    ${CXX_ABI_ARGS} \
 ##
 
 make -j${CPU_COUNT}

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -16,7 +16,7 @@ else
     DYLIB_EXT=so
     CC=gcc
     CXX=g++
-    CXXFLAGS="${CFLAGS} -std=c++11"
+    CXXFLAGS="${CFLAGS} -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0"
 fi
 
 mkdir build

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -16,7 +16,11 @@ else
     DYLIB_EXT=so
     CC=gcc
     CXX=g++
-    CXXFLAGS="${CFLAGS} -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0"
+    CXXFLAGS="${CFLAGS} -std=c++11"
+    # enable compilation without CXX abi to stay compatible with gcc < 5 built packages
+    if [[ ${DO_NOT_BUILD_WITH_CXX11_ABI} == '1' ]]; then
+        CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${CXXFLAGS}"
+    fi
 fi
 
 mkdir build
@@ -30,6 +34,7 @@ cmake ..\
     -DPYTHON_EXECUTABLE=${PYTHON} \
     -DPYTHON_LIBRARY=${PREFIX}/lib/libpython${PY_ABI}.${DYLIB_EXT} \
     -DPYTHON_INCLUDE_DIR=${PREFIX}/include/python${PY_ABI} \
+    ${CXX_ABI_ARGS} \
 ##
 
 make -j${CPU_COUNT}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,12 +21,12 @@ requirements:
     - python >=2.7
     - python {{PY_VER}}*
     - boost 1.63.0.*
-    - numpy
+    - numpy {{NPY_VER}}*
     - pybind11
   run:
     - python {{PY_VER}}*
     - boost 1.63.0.*
-    - numpy
+    - numpy {{NPY_VER}}*
 
 test:
   imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   path: ../
 
 build:
-  number: 0
+  number: 1
   string: py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
   script_env:
     # Control building with CXX11 abi

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,10 +20,12 @@ requirements:
     - cmake
     - python >=2.7
     - python {{PY_VER}}*
+    - boost 1.63.0.*
     - numpy
     - pybind11
   run:
     - python {{PY_VER}}*
+    - boost 1.63.0.*
     - numpy
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,12 +21,11 @@ requirements:
     - python >=2.7
     - python {{PY_VER}}*
     - boost 1.63.0.*
-    - numpy {{NPY_VER}}*
     - pybind11
   run:
     - python {{PY_VER}}*
     - boost 1.63.0.*
-    - numpy {{NPY_VER}}*
+    - numpy
 
 test:
   imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,8 +12,11 @@ source:
   path: ../
 
 build:
-  number: 2
+  number: 0
   string: py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
+  script_env:
+    # Control building with CXX11 abi
+    - DO_NOT_BUILD_WITH_CXX11_ABI  # [linux]
 
 requirements:
   build:


### PR DESCRIPTION
This is related to allowing dependencies to be built with newer gcc than the one available through conda (4.8.5 atm), in particular, recent nifty changes forced us to use a newer compiler.

See some more background on this in https://github.com/ilastik/ilastik-publish-packages/issues/2

In order to use the system compilers this PR removes

* references to `gcc`, `libgcc` in the respective `meta.yaml` files
* points to the correct compiler in `build.sh`
* introduces an environment variable `DO_NOT_BUILD_WITH_CXX11_ABI` that is used in the build process to enable building with `-D_GLIBCXX_USE_CXX11_ABI=0` to enable compatibility with the "old" gcc stdlib abi.