### PR TITLE
Fix windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(marching_cubes)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
+
 
 include(CheckCXXCompilerFlag)
 set(CMAKE_CXX_STANDARD 11)
@@ -28,8 +30,8 @@ if (OPENMP_FOUND)
 endif()
 
 
-set(WINDOWS_EXPORT_ALL_SYMBOLS 1)
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
+# set(WINDOWS_EXPORT_ALL_SYMBOLS 1)
+# set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
 
 
 include_directories(src)
@@ -47,27 +49,15 @@ pybind11_add_module(marching_cubes
 # INSTALL THE PYTHON MODULE
 #################################
 
-IF(NOT DEFINED PYTHON_MODULE_INSTALL_DIR OR PYTHON_MODULE_INSTALL_DIR MATCHES "^$")
-
-
-    execute_process(
-      COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
-        from distutils import sysconfig as sc
-        print(sc.get_python_lib(prefix='', plat_specific=True))"
-      OUTPUT_VARIABLE PYTHON_SITE
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    execute_process(
-      COMMAND "${PYTHON_EXECUTABLE}" -c "from __future__ import print_function; from distutils.sysconfig import get_python_lib; print(get_python_lib())"
-      OUTPUT_VARIABLE PYTHON_SITE
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    SET(PYTHON_MODULE_INSTALL_DIR ${PYTHON_SITE})
-
-ENDIF()
+if(NOT DEFINED PYTHON_MODULE_INSTALL_DIR OR PYTHON_MODULE_INSTALL_DIR MATCHES "^$")
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+                    "from distutils.sysconfig import *; print(get_python_lib(1))"
+                    OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+  FILE(TO_CMAKE_PATH ${PYTHON_SITE_PACKAGES} PYTHON_MODULE_INSTALL_DIR)
+endif()
 
 SET(PYTHON_MODULE_INSTALL_DIR ${PYTHON_MODULE_INSTALL_DIR}
-    CACHE PATH "where to install the Nifty Python package" FORCE)
+    CACHE PATH "where to install the marching cubres Python package" FORCE)
 
 # this is the install path relative to CMAKE_INSTALL_PREFIX,
 # use this in INSTALL() commands to get packaging right

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(marching_cubes)
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
-
 
 include(CheckCXXCompilerFlag)
 set(CMAKE_CXX_STANDARD 11)

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,8 +1,11 @@
 mkdir build
 cd build
+
+set CONFIGURATION=Release
+
 cmake .. -G "%CMAKE_GENERATOR%" ^
     -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
-    -DCMAKE_INSTALL_PREFIX="%PREFIX%" ^
+    -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
     -DPYTHON_EXECUTABLE="%PYTHON%"
 
 if errorlevel 1 exit 1


### PR DESCRIPTION
Long story short: on windows, the package was built in `DEBUG` mode, all other packages are build in `RELEASE`. That resulted in `dll`-clashes.
Also did some cleanups.