### PR TITLE
conda-recipe: No need for boost as a runtime dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
 env:
   global:
     - CONDA_ROOT=$HOME/miniconda
+    - MACOSX_DEPLOYMENT_TARGET=10.9
+    - CONDA_BUILD_SYSROOT="$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk"
     - TEST_ENV=test-env
     - TEST_ENV_PREFIX=$CONDA_ROOT/envs/$TEST_ENV
     - NOSETEST_OUT_DIR=${CIRCLE_ARTIFACTS}/lazyflow-nose
@@ -19,6 +21,10 @@ cache:
     - CONDA_ROOT
 
 install:
+  - >
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      echo -e "CONDA_BUILD_SYSROOT:\n  - ${CONDA_BUILD_SYSROOT}" >> conda-recipe/conda_build_config.yaml;
+    fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export MINICONDA=https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2017
+
 clone_folder: c:\projects\marching_cubes
 
 environment:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - {{ compiler("cxx") }}
   host:
     - python {{ python }}
-    - boost {{ boost }}
+    - boost-cpp {{ boost }}
     - pybind11
   run:
     - python {{ python }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 0001-ssize_t-in-parallel-fors-for-windows.patch  # [win]
 
 build:
-  number: 1000
+  number: 1001
   string: py{{CONDA_PY}}_{{PKG_BUILDNUM}}_h{{PKG_HASH}}_g{{GIT_FULL_HASH[:7]}}
 
 requirements:
@@ -29,7 +29,6 @@ requirements:
     - pybind11
   run:
     - python {{ python }}
-    - boost {{ boost }}
     - numpy >=1.12
 
 test:


### PR DESCRIPTION
In this code base, `boost` is only used for `flat_set` from `boost::container`, which is a header-only library.