### PR TITLE
Upgrade osx image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   global:
     - CONDA_ROOT=$HOME/miniconda
     - MACOSX_DEPLOYMENT_TARGET=10.9
-    - CONDA_BUILD_SYSROOT="$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk"
+    - CONDA_BUILD_SYSROOT="$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
     - TEST_ENV=test-env
     - TEST_ENV_PREFIX=$CONDA_ROOT/envs/$TEST_ENV
     - NOSETEST_OUT_DIR=${CIRCLE_ARTIFACTS}/lazyflow-nose
@@ -24,6 +24,8 @@ install:
   - >
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       echo -e "CONDA_BUILD_SYSROOT:\n  - ${CONDA_BUILD_SYSROOT}" >> conda-recipe/conda_build_config.yaml;
+      # debug
+      cat conda-recipe/conda_build_config.yaml;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - os: linux
       dist: trusty
     - os: osx
-      osx_image: xcode6.4
+      osx_image: xcode9.4
 
 env:
   global:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - cmake
     - {{ compiler("cxx") }}
   host:
-    - python {{ python }}
+    - python
     - boost-cpp {{ boost }}
     - pybind11
   run:


### PR DESCRIPTION
travis xcode6.4 image is deprecated. Use 9.4 (current default).