### PR TITLE
Added (currently) failing test for correctness

### DIFF
--- a/test/test_marching_correctness.py
+++ b/test/test_marching_correctness.py
@@ -1,0 +1,19 @@
+import marching_cubes
+import numpy
+import pytest
+
+
+@pytest.fixture
+def data():
+    """Test volume with non-zero voxels parallel to axes"""
+    data = numpy.zeros((17, 19, 23)).astype("uint32")
+    data[1:7, 1:2, 1:2] = 1  # z-axis
+    data[1:2, 1:9, 1:2] = 1  # y-axis
+    data[1:2, 1:2, 1:11] = 1  # x-axis
+    return data
+
+
+def test_marching_orientation(data):
+    v, _, _ = marching_cubes.march(data, 0)
+    max_v = v.max(axis=0)
+    numpy.testing.assert_array_almost_equal(max_v, [10.5, 8.5, 6.5])


### PR DESCRIPTION
imo marching cubes should deliver correct results under the assumption of C-ordered arrays with x as fastest varying index.
I added a test that demonstrates that this is currently not the case; sample test output:


```
=================================== FAILURES ===================================
__________________________ test_marching_orientation ___________________________

data = array([[[0, 0, 0, ..., 0, 0, 0],
        [0, 0, 0, ..., 0, 0, 0],
        [0, 0, 0, ..., 0, 0, 0],
        ...,
      ......,
        [0, 0, 0, ..., 0, 0, 0],
        [0, 0, 0, ..., 0, 0, 0],
        [0, 0, 0, ..., 0, 0, 0]]], dtype=uint32)

    def test_marching_orientation(data):
        v, _, _ = marching_cubes.march(data, 0)
        max_v = v.max(axis=0)
>       numpy.testing.assert_array_almost_equal(max_v, [10.5, 8.5, 6.5])
E       AssertionError: 
E       Arrays are not almost equal to 6 decimals
E       
E       Mismatched elements: 2 / 3 (66.7%)
E       Max absolute difference: 4.
E       Max relative difference: 0.61538462
E        x: array([ 6.5,  8.5, 10.5], dtype=float32)
E        y: array([10.5,  8.5,  6.5])
```

here one can see, that z and x coordinates are flipped.

See also #34 